### PR TITLE
Let process runtime be affected by architecture

### DIFF
--- a/src/bitwise/process.cljs
+++ b/src/bitwise/process.cljs
@@ -22,7 +22,7 @@
   (progress [this]
     (if (running? this)
       (let [elapsed (- (util/timestamp) (:started-at this))]
-        (max (min (/ (util/ms->sec elapsed) (duration this)) 1.0) 0.0))
+        (util/clamp (/ (util/ms->sec elapsed) (duration this))))
       0.0))
   (complete? [this]
     (and (running? this)

--- a/src/bitwise/process.cljs
+++ b/src/bitwise/process.cljs
@@ -7,7 +7,9 @@
   (stop [this])
   (running? [this])
   (complete? [this])
-  (progress [this]))
+  (progress [this])
+  (complexity [this])
+  (duration [this]))
 
 (defrecord Process [pid program started-at]
   Executable
@@ -19,15 +21,19 @@
     (not (nil? (:started-at this))))
   (progress [this]
     (if (running? this)
-      (let [elapsed (- (util/timestamp) (:started-at this))
-            duration (get-in program-catalog [(:program this) :complexity])]
-        (max (min (/ (util/ms->sec elapsed) duration) 1.0) 0.0))
+      (let [elapsed (- (util/timestamp) (:started-at this))]
+        (max (min (/ (util/ms->sec elapsed) (duration this)) 1.0) 0.0))
       0.0))
   (complete? [this]
     (and (running? this)
          (>= (util/timestamp)
-             (+ (:started-at this) (util/sec->ms
-                                    (get-in program-catalog [(:program this) :complexity])))))))
+             (+ (:started-at this) (util/sec->ms (duration this))))))
+  (complexity [this]
+    (get-in program-catalog [(:program this) :complexity]))
+  (duration [this]
+    (if-let [duration (:duration this)]
+      duration
+      (complexity this))))
 
 (deftype ProcessHandler []
   Object

--- a/src/bitwise/reducers.cljs
+++ b/src/bitwise/reducers.cljs
@@ -17,8 +17,8 @@
   (let [process (get-in state [:processes pid])]
     (if (process/running? process)
       state
-      (let [architecture (get-in state [:architecture])
-            duration (/ (process/complexity process) (get-in architecture [:cpu :speed]))]
+      (let [cpu-speed (get-in state [:architecture :cpu :speed])
+            duration (/ (process/complexity process) cpu-speed)]
         (assoc-in state [:processes pid] (-> process
                                              (process/start)
                                              (assoc-in [:duration] duration)))))))

--- a/src/bitwise/reducers.cljs
+++ b/src/bitwise/reducers.cljs
@@ -17,10 +17,17 @@
   (let [process (get-in state [:processes pid])]
     (if (process/running? process)
       state
-      (update-in state [:processes pid] process/start))))
+      (let [architecture (get-in state [:architecture])
+            duration (/ (process/complexity process) (get-in architecture [:cpu :speed]))]
+        (assoc-in state [:processes pid] (-> process
+                                             (process/start)
+                                             (assoc-in [:duration] duration)))))))
 
 (defmethod reduce-game-state :complete-process [state {:keys [pid]}]
-  (update-in state [:processes pid] process/stop))
+  (let [process (get-in state [:processes pid])]
+    (assoc-in state [:processes pid] (-> process
+                                         (process/stop)
+                                         (dissoc :duration)))))
 
 (defmethod reduce-game-state :increase-resource [state {:keys [resource amount]}]
   (update-in state [:resources resource] (comp

--- a/src/bitwise/util.cljs
+++ b/src/bitwise/util.cljs
@@ -29,3 +29,7 @@
     "Merge multiple nested maps."
     [& args]
     (reduce merge-deep* nil args)))
+
+(defn clamp
+  ([v] (clamp v 0.0 1.0))
+  ([v lo hi] (max lo (min v hi))))


### PR DESCRIPTION
This is handled via some convenience methods on the Process record, and more directly, in the game-state reducer, so that we don't have to pass the architecture around the entire application.